### PR TITLE
fix dwn.mk for it works for .tar.gz

### DIFF
--- a/deploy/dwn.mk
+++ b/deploy/dwn.mk
@@ -48,19 +48,16 @@ ifeq ($(OS_detected),Darwin)
 	@echo 
 	@echo Detected Darwin ...
 	curl -LO $(DWN_URL)
+	tar -zxvf $(DWN_FILENAME)
 
 	# check file extension
-ifeq ($(DWN_FILENAME_EXT),'.gz')
-	@echo Detected file ext .gz ...
-    tar -zxvf $(DWN_FILENAME)
-else
-	@echo Detected file ext "" ...
-    # if "none", its a pure binary, so just rename it to the requires DWN_BIN_FSPATH
-endif
-	
-	
-	
-
+#ifeq ($(DWN_FILENAME_EXT),'.gz')
+#	@echo Detected file ext .gz ...
+#    tar -zxvf $(DWN_FILENAME)
+#else
+#	@echo Detected file ext "" ...
+#    # if "none", its a pure binary, so just rename it to the requires DWN_BIN_FSPATH
+#endif
 
 	
 endif

--- a/deploy/projects/org-y/makefile
+++ b/deploy/projects/org-y/makefile
@@ -74,9 +74,8 @@ dep-os:
 #	GO111MODULE="off" go get github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb
 #	go get -u -v github.com/go-bindata/go-bindata/...
 #	go get -u -v github.com/google/go-jsonnet/cmd/jsonnet
-#	$(MAKE) hug-dep
-#	$(MAKE) fly-dep
-#	$(MAKE) gor-dep
+	$(MAKE) fly-dep
+	$(MAKE) gor-dep
 
 dep-os-delete:
 	$(MAKE) hug-dep-delete


### PR DESCRIPTION
commented out file extension logic as it broke some downloads.

will uncomment once i get the file extension logic working again.
its was only sops download that it was needed for and i am increasingly thinking that SOPS is overkill.